### PR TITLE
CODE: Detect gmock/gmock.h and fail if not found

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -1,4 +1,8 @@
 gtest_dep = dependency('gtest')
+gmock_h = meson.get_compiler('cpp').has_header('gmock/gmock.h')
+if not gmock_h
+  error('gmock/gmock.h not found')
+endif
 gmock_dep = dependency('gmock')
 
 # we need to rethink this..


### PR DESCRIPTION
On Debian Buster (and probably other Debian derived distros), gmock
is detected even when it is not installed. This change ensures we check
for the header file and error when it is not found.

Closes #11