### PR TITLE
Add option to prevent service restart

### DIFF
--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -54,6 +54,8 @@ int Config::module_change(sysrepo::S_Session session, const char* module_name,
       setLogFormat(getOption("logging/timestamp", session) == "true");
       d_pdns_service = getOption("pdns-service/name", session);
       d_pdns_conf = getOption("pdns-service/config-file", session);
+      auto restartOpt = getOption("pdns-service/restart", session);
+      d_pdns_restart = (restartOpt == "true");
     }
     catch (const sysrepo::sysrepo_exception& e) {
       spdlog::warn("Unable to retrieve initial config due to sysrepo error: {}", e.what());
@@ -91,6 +93,8 @@ int Config::module_change(sysrepo::S_Session session, const char* module_name,
             setLoglevel(leaf->value_str());
           } else if (path == "/pdns-server:pdns-sysrepo/logging/timestamp") {
             setLogFormat(leaf->value()->bln());
+          } else if (path == "/pdns-server:pdns-sysrepo/pdns-service/restart") {
+            d_pdns_restart = (leaf->value()->bln());
           }
         }
       }

--- a/src/config/config.hh
+++ b/src/config/config.hh
@@ -38,6 +38,14 @@ public:
    */
   string getServiceName() { return d_pdns_service; };
 
+  /**
+   * @brief Whether or not the PowerDNS service should be restarted
+   * 
+   * @return true 
+   * @return false 
+   */
+  bool getDoServiceRestart() { return d_pdns_restart; };
+
   int module_change(sysrepo::S_Session session, const char* module_name,
     const char* xpath, sr_event_t event,
     uint32_t request_id, void* private_data) override;
@@ -64,6 +72,12 @@ private:
   string getOption(const string &opt, sysrepo::S_Session &session);
   string d_pdns_service;
   string d_pdns_conf;
+
+  /**
+   * @brief Whether or not the PowerDNS service should be restarted on config changes
+   * 
+   */
+  bool d_pdns_restart;
 
   /**
    * @brief Indicates that the initial load failed

--- a/src/pdns-config/config-update.cc
+++ b/src/pdns-config/config-update.cc
@@ -23,6 +23,10 @@ void PdnsConfigCB::changeConfigUpdate(sysrepo::S_Session& session, const uint32_
   auto change = session->get_change_tree_next(iter);
 
   if (change != nullptr) {
+    if (!d_config->getDoServiceRestart() && !isFromEnabled) {
+      session->set_error("Unable to process configuration changes, service may not restart", nullptr);
+      throw std::runtime_error("Service restarts are disabled");
+    }
     pdnsConfigChanged = true;
     auto fpath = tmpFile(request_id);
 

--- a/src/pdns-config/pdns-config-callback.cc
+++ b/src/pdns-config/pdns-config-callback.cc
@@ -108,7 +108,7 @@ int PdnsConfigCB::module_change(sysrepo::S_Session session, const char* module_n
         return SR_ERR_OPERATION_FAILED;
       }
 
-      if (!d_config->getServiceName().empty()) {
+      if (!d_config->getDoServiceRestart()) {
         restartService(d_config->getServiceName());
       }
 

--- a/src/pdns-config/pdns-config-callback.hh
+++ b/src/pdns-config/pdns-config-callback.hh
@@ -152,6 +152,7 @@ protected:
   std::vector<string> zonesRemoved;
   bool pdnsConfigChanged{false};
   bool apiConfigChanged{false};
+  bool isFromEnabled{false};
 };
 
 /**

--- a/test/remote-backend/config-initial.in.json
+++ b/test/remote-backend/config-initial.in.json
@@ -74,8 +74,8 @@
   ],
   "pdns-server:pdns-sysrepo": {
     "pdns-service": {
-      "name": "pdns-sysrepo-test.service",
-      "config-file": "@pdns-config-file@"
+      "config-file": "@pdns-config-file@",
+      "restart": false
     },
     "logging": {
       "level": "trace",

--- a/yang/pdns-server.yang
+++ b/yang/pdns-server.yang
@@ -45,6 +45,10 @@ module pdns-server {
     description
       "This module describes the PowerDNS Authoritative Server";
 
+    revision 2020-02-13 {
+      description "Add option to not restart te PowerDNS service";
+    }
+
     revision 2020-02-06 {
       description "Add DNAME to supported rrset types";
     }
@@ -622,6 +626,13 @@ module pdns-server {
         }
         leaf config-file {
           type string; // TODO use a filepath-style type
+        }
+        leaf restart {
+          type boolean;
+          default true;
+          description
+                  "Restart the PowerDNS Authoritative Server service when the configuration in
+                   /pdns-server:pdns-server/ or /pdns-server:pdns-sysrepo/service is changed";
         }
       }
 


### PR DESCRIPTION
Can be handy in tests, or when an operator does not care for config changes being applied

ToDo:

 - [x] Reject all config changes in the running datastore when restarts are disabled